### PR TITLE
fix: poll maker amount issue

### DIFF
--- a/api1.js
+++ b/api1.js
@@ -869,7 +869,17 @@ function safelyShutdownTaker(takerInstance) {
 }
 
 function toNumber(value, fallback = 0) {
-  const normalized = Number(value);
+  if (value && typeof value === 'object') {
+    for (const key of ['sats', 'value', 'amount']) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        const nested = toNumber(value[key], NaN);
+        if (Number.isFinite(nested)) return nested;
+      }
+    }
+  }
+
+  const normalized =
+    typeof value === 'string' ? Number(value.replace(/,/g, '')) : Number(value);
   return Number.isFinite(normalized) ? normalized : fallback;
 }
 
@@ -2349,9 +2359,9 @@ function registerTakerHandlers() {
           fidelity: {
             bond: {
               outpoint: outpointStr,
-              amount: bond.amount || 0,
-              lock_time: bond.lockTime || 0,
-              is_spent: bond.isSpent || false,
+              amount: toNumber(bond.amount, 0),
+              lock_time: toNumber(bond.lockTime ?? bond.lock_time, 0),
+              is_spent: Boolean(bond.isSpent ?? bond.is_spent),
             },
           },
         };


### PR DESCRIPTION
Currently when we poll a maker, it shows the fidelity bond amount to N/A, though it still points to right fidelity bond data, but it shows the bond amount and expiry days as NaN.
<img width="718" height="388" alt="image" src="https://github.com/user-attachments/assets/cf9dc8fe-329b-481b-8c37-ba5cc12c7847" />
<img width="1646" height="819" alt="image" src="https://github.com/user-attachments/assets/7745c46b-c6d4-47ea-b3b0-7e80fa8b8a18" />


This pr intends to fix this behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved numeric input normalization to handle various data formats, alternative property names, and formatted numbers (e.g., with commas)
  * Enhanced fidelity bond data normalization for more accurate processing of bond status and timelock values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->